### PR TITLE
Fix broken emphasis markup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Execution: Using cURL, the script authenticates with a valid roundcube_sessid co
 
 Output: Success is confirmed by a "File written successfully" message, and the server response is saved to response.html for debugging.
 
-**The PoC was tested successfully on June 05, 2025, creating the file in the public_html directory. Note that a valid session cookie is required, and the target path must be writable by the web server user.
-**
+**The PoC was tested successfully on June 05, 2025, creating the file in the public_html directory. Note that a valid session cookie is required, and the target path must be writable by the web server user.**
 
 ## Security Recommendations
 
@@ -38,7 +37,6 @@ To mitigate the risks associated with CVE-2025-49113, follow these steps:
 - Disable Unused Features: If possible, disable the settings upload feature if not required.
 
 
-**Warning: This PoC is for educational purposes only. Unauthorized exploitation of this vulnerability is illegal and may violate local laws.
-**
+**Warning: This PoC is for educational purposes only. Unauthorized exploitation of this vulnerability is illegal and may violate local laws.**
 
 Rasool13x :)


### PR DESCRIPTION
Refer to the diff for the problem this deals with.